### PR TITLE
fix `fns show` error

### DIFF
--- a/docs/general/node_init.sh
+++ b/docs/general/node_init.sh
@@ -68,7 +68,7 @@ stt issue || exit 1
 stt transfer -f root -t ${xfr_pubkey} -n $((10000 * 10000 * 1000000)) || exit 1
 sleep 30
 
-if [[ 0 -eq `fns show | grep -A 1 "Your Balance" | sed 's/ FRA units *$//'` ]]; then
+if [[ 0 -eq `fns show 2>&1 | grep -A 1 "Your Balance" | sed 's/ FRA units *$//' | tail -1` ]]; then
     echo -e "Transfer FRAs to your address failed !"
     exit 1
 fi


### PR DESCRIPTION
`fns show` will report error because of missing validator-pubkey

```
Error: ...
|-- file: components/fintools/src/bins/fns.rs
|-- line: 117
`-- column: 23
Caused By: unable to obtain complete information
|-- file: components/fintools/src/fns/mod.rs
|-- line: 174
`-- column: 13
+ [[ 0 -eq Your Balance:
100000000000000 ]]
node_init.sh: line 72: [[: Your Balance:
100000000000000: syntax error: operand expected (error token is "Your Balance:
100000000000000")
+ exit 0
```