### PR TITLE
start tendermint with default db_backend

### DIFF
--- a/docs/general/node_init.sh
+++ b/docs/general/node_init.sh
@@ -100,11 +100,11 @@ cd ${LEDGER_DIR}/abci
 nohup abci_validator_node &
 
 cd ${LEDGER_DIR}/tendermint
-nohup tendermint node --db_backend=cleveldb &
+nohup tendermint node &
 
 sleep 5
 
-curl 'http://localhost:26657/status'
-curl 'http://localhost:8669/version'
-curl 'http://localhost:8668/version'
-curl 'http://localhost:8667/version'
+curl 'http://localhost:26657/status'; echo
+curl 'http://localhost:8669/version'; echo
+curl 'http://localhost:8668/version'; echo
+curl 'http://localhost:8667/version'; echo


### PR DESCRIPTION
nod_init.sh fails to start tendermint with cleveldb
```
panic: Unknown db_backend cleveldb, expected either memdb or goleveldb

goroutine 1 [running]:
github.com/tendermint/tm-db.NewDB(0x1004eec, 0xa, 0x7ffd1ddf7582, 0x8, 0xc0000376a0, 0x1c, 0xe7dd60, 0xc000581bf8)
        github.com/tendermint/tm-db@v0.5.1/db.go:63 +0x3a8
github.com/tendermint/tendermint/node.DefaultDBProvider(0xc00013f8c0, 0xc00013f8c0, 0x203000, 0x203000, 0x203000)
        github.com/tendermint/tendermint/node/node.go:67 +0xea
github.com/tendermint/tendermint/node.initDBs(0xc000012a00, 0x117b108, 0xc000292e18, 0x756ea1d3aae220, 0xf422eb956acf64f, 0xc0000b2fe0, 0x7f25befdab10)
        github.com/tendermint/tendermint/node/node.go:190 +0x6c
github.com/tendermint/tendermint/node.NewNode(0xc000012a00, 0x127e2a0, 0xc00029a5a0, 0xc000350e30, 0x1269c40, 0xc000584690, 0xc000350ff0, 0x117b108, 0xc000351000, 0x1282908, ...)
        github.com/tendermint/tendermint/node/node.go:553 +0x50
github.com/tendermint/tendermint/node.DefaultNewNode(0xc000012a00, 0x1282908, 0xc00017a720, 0xc0000b3c60, 0xd4483c, 0xc00013d340)
        github.com/tendermint/tendermint/node/node.go:95 +0x4e9
github.com/tendermint/tendermint/cmd/tendermint/commands.NewRunNodeCmd.func1(0xc00013d340, 0xc000094690, 0x0, 0x1, 0x0, 0x0)
        github.com/tendermint/tendermint/cmd/tendermint/commands/run_node.go:106 +0x7d
github.com/spf13/cobra.(*Command).execute(0xc00013d340, 0xc000094680, 0x1, 0x1, 0xc00013d340, 0xc000094680)
        github.com/spf13/cobra@v1.0.0/command.go:842 +0x472
github.com/spf13/cobra.(*Command).ExecuteC(0x1861000, 0x2, 0x2, 0xc00027e1e0)
        github.com/spf13/cobra@v1.0.0/command.go:950 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.0.0/command.go:887
github.com/tendermint/tendermint/libs/cli.Executor.Execute(0x1861000, 0x117cc88, 0x2, 0xc0002862e8)
        github.com/tendermint/tendermint/libs/cli/setup.go:89 +0x3c
main.main()
        github.com/tendermint/tendermint/cmd/tendermint/main.go:48 +0x285
```