### PR TITLE
Update 07-hardhat.md

### DIFF
--- a/docs/dapp/07-hardhat.md
+++ b/docs/dapp/07-hardhat.md
@@ -43,7 +43,7 @@ module.exports = {
     },
     findora: {
       url: "https://prod-forge.prod.findora.org:8545",
-      chainId:523,
+      chainId:525,
       accounts: [mnemonic]
     }
   },


### PR DESCRIPTION
Hardhat was set to use chain id 523, but connected to a chain with id 525.