### PR TITLE
Adding config to enable GA tracking

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -92,6 +92,10 @@ module.exports = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
+        googleAnalytics: {
+          trackingID: 'UA-143942502-1',
+          anonymizeIP: true,
+        },
       },
     ],
   ],


### PR DESCRIPTION
According to docusaurus documentation, this is the way to add Google analytics tracking to docusaurus. Please review. Thanks!

https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-analytics