### PR TITLE
Update manual validator docs

### DIFF
--- a/docs/guides/manual-setup.md
+++ b/docs/guides/manual-setup.md
@@ -57,9 +57,12 @@ sudo chown -R `id -u`:`id -g` ${ROOT_DIR}/tendermint/
 ```shell
 # Testnet
 export NAMESPACE=testnet
+
 # Mainnet
 export NAMESPACE=mainnet
-wget -O "${ROOT_DIR}/latest" "https://prod-${NAMESPACE}-us-west-2-chain-data-backup.s3.us-west-2.amazonaws.com/latest"
+export SNAPSHOT_VERSION=01
+
+wget -O "${ROOT_DIR}/latest" "https://prod-${NAMESPACE}${SNAPSHOT_VERSION}-us-west-2-chain-data-backup.s3.us-west-2.amazonaws.com/latest"
 export CHAINDATA_URL=$(cut -d , -f 1 "${ROOT_DIR}/latest")
 wget -O "${ROOT_DIR}/snapshot" "${CHAINDATA_URL}"
 mkdir "${ROOT_DIR}/snapshot_data"

--- a/docs/guides/manual-setup.md
+++ b/docs/guides/manual-setup.md
@@ -98,9 +98,9 @@ Key: {
 ### Store security key
 ```shell
 # For Testnet
-echo ${ROOT_DIR}/tmp.gen.keypair > ${ROOT_DIR}/testnet_node.key
+cat ${ROOT_DIR}/tmp.gen.keypair > ${ROOT_DIR}/testnet_node.key
 # For Mainnet
-echo ${ROOT_DIR}/tmp.gen.keypair > ${ROOT_DIR}/mainnet_node.key
+cat ${ROOT_DIR}/tmp.gen.keypair > ${ROOT_DIR}/mainnet_node.key
 ```
 #### Store Mnemonic Words into ${ROOT_DIR}/node.mnemonic
 For convenience in setting up your node via the `fn` tool, store your 24 mnemonic keywords (located inside `tmp.gen.keypair`) into ${ROOT_DIR}/node.mnemonic.


### PR DESCRIPTION
The snapshot host in the docs for mainnet is incorrect. The correct host is `prod-mainnet01-us-west-2-chain-data-backup.s3.amazonaws.com`.

`01` is currently only required for mainnet.

```shell
# Mainnet
Connecting to prod-mainnet01-us-west-2-chain-data-backup.s3.amazonaws.com (prod-mainnet01-us-west-2-chain-data-backup.s3.amazonaws.com)|52.218.216.251|:443... connected.
HTTP request sent, awaiting response... 200 OK
```

```shell
# Testnet
Connecting to prod-testnet-us-west-2-chain-data-backup.s3.amazonaws.com (prod-testnet-us-west-2-chain-data-backup.s3.amazonaws.com)|52.218.136.163|:443... connected.
HTTP request sent, awaiting response... 200 OK
```

Additionally, two `echo` commands were changed to `cat`.